### PR TITLE
Removed JSONP callback parameter + related hardcoded string magic, added support for date/time limiting board searches

### DIFF
--- a/pysttrafik.py
+++ b/pysttrafik.py
@@ -306,7 +306,7 @@ class LegHalf(object):
         
 class Leg(object):
     '''
-    a Leg is part of a Trip, and is performed on one veichle or by foot.
+    a Leg is part of a Trip, and is performed on one vehicle or by foot.
     
     it has an origin and a destination of type LegHalf
     '''


### PR DESCRIPTION
For more reliable (and standardized) JSON decoding of responses, I removed the callback parameter that were sent with all requests. This parameter creates a JS function scope around the response data, which is supposed to be passed to a browser handler when done, in some capacity.

When this was removed, the additional substr massage of response data went along as well.

As a bonus I also added parsing of datetime parameter in the board method.

This pull request should be updated with the latest HEAD from ltworf/master.
